### PR TITLE
Run the animations when the page renders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export default {
         const scrollAnimate = ScrollAnimate(Date.now())
         const previousClassName = el.className
         let lastScrollTop = window.pageYOffset
+        scrollAnimate.run(el, binding, {isUpwards: false, previousClassName})
         window.addEventListener('scroll', function() {
           let scrollTop = window.pageYOffset || document.documentElement.scrollTop
           const isUpwards = scrollTop < lastScrollTop


### PR DESCRIPTION
This allows the animations to be properly initialised without scrolling the page.